### PR TITLE
[WS-01] Extend Chat Session Model

### DIFF
--- a/mcp-web-client/src/services/chatService.ts
+++ b/mcp-web-client/src/services/chatService.ts
@@ -45,7 +45,11 @@ export const saveChatSessions = (sessions: ChatSession[]): void => {
 };
 
 // Create a new chat session
-export const createChatSession = (title: string = 'New Chat'): ChatSession => {
+export const createChatSession = (
+  title: string = 'New Chat',
+  workspaceId?: string,
+  currentWorkingDirectory?: string
+): ChatSession => {
   const sessions = getChatSessions();
   
   const newSession: ChatSession = {
@@ -53,7 +57,9 @@ export const createChatSession = (title: string = 'New Chat'): ChatSession => {
     title,
     messages: [],
     createdAt: new Date(),
-    updatedAt: new Date()
+    updatedAt: new Date(),
+    workspaceId,
+    currentWorkingDirectory
   };
   
   console.log('Creating new session:', newSession);
@@ -82,6 +88,26 @@ export const updateChatSession = (updatedSession: ChatSession): void => {
     // Update the session with the new data and update timestamp
     sessions[index] = {
       ...updatedSession,
+      updatedAt: new Date()
+    };
+    saveChatSessions(sessions);
+  }
+};
+
+// Update workspace and CWD for a chat session
+export const updateChatSessionWorkspace = (
+  sessionId: string, 
+  workspaceId?: string, 
+  currentWorkingDirectory?: string
+): void => {
+  const sessions = getChatSessions();
+  const index = sessions.findIndex(session => session.id === sessionId);
+  
+  if (index !== -1) {
+    sessions[index] = {
+      ...sessions[index],
+      workspaceId,
+      currentWorkingDirectory,
       updatedAt: new Date()
     };
     saveChatSessions(sessions);

--- a/mcp-web-client/src/types.ts
+++ b/mcp-web-client/src/types.ts
@@ -11,6 +11,8 @@ export interface ChatSession {
   messages: Message[];
   createdAt: Date;
   updatedAt: Date;
+  workspaceId?: string;
+  currentWorkingDirectory?: string;
 }
 
 export interface McpServerConfig {


### PR DESCRIPTION
## Description
This PR addresses issue #3 by extending the ChatSession model to include workspace and current working directory (CWD) fields.

## Changes Made
- Updated the `ChatSession` interface in `types.ts` to include optional `workspaceId` and `currentWorkingDirectory` fields
- Modified `chatService.ts` to support these new fields:
  - Updated `createChatSession()` to accept and store the new fields
  - Added a new `updateChatSessionWorkspace()` function to update workspace-related fields
  - Ensured backward compatibility with existing chat sessions

## Testing
The implementation ensures backward compatibility by:
- Making the new fields optional
- Not requiring the fields when parsing existing sessions
- Preserving existing functionality for sessions without these fields

## Closes
Closes #3
