### PR TITLE
[WS-02] Create Workspace Service

### DIFF
--- a/mcp-web-client/src/services/__tests__/workspaceService.test.ts
+++ b/mcp-web-client/src/services/__tests__/workspaceService.test.ts
@@ -1,0 +1,200 @@
+// Import the workspace service functions
+import {
+  createWorkspace,
+  getWorkspaces,
+  getWorkspaceById,
+  updateWorkspace,
+  deleteWorkspace,
+  setCurrentWorkspace,
+  getCurrentWorkspace,
+  getCurrentWorkspaceId,
+  clearCurrentWorkspace,
+  ensureCurrentWorkspace
+} from '../workspaceService';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: jest.fn((key: string) => store[key] || null),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: jest.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: jest.fn(() => {
+      store = {};
+    })
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+describe('Workspace Service', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('createWorkspace', () => {
+    it('should create a new workspace with required fields', () => {
+      const workspace = createWorkspace('Test Workspace', '/test/path');
+      
+      expect(workspace).toHaveProperty('id');
+      expect(workspace.name).toBe('Test Workspace');
+      expect(workspace.rootPath).toBe('/test/path');
+      expect(workspace.createdAt).toBeInstanceOf(Date);
+      expect(workspace.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it('should create a workspace with optional fields when provided', () => {
+      const workspace = createWorkspace(
+        'Test Workspace',
+        '/test/path',
+        'Test description',
+        'icon-name',
+        '#ff0000'
+      );
+      
+      expect(workspace.description).toBe('Test description');
+      expect(workspace.icon).toBe('icon-name');
+      expect(workspace.color).toBe('#ff0000');
+    });
+  });
+
+  describe('getWorkspaces', () => {
+    it('should return an empty array when no workspaces exist', () => {
+      const workspaces = getWorkspaces();
+      expect(workspaces).toEqual([]);
+    });
+
+    it('should return workspaces when they exist', () => {
+      createWorkspace('Workspace 1', '/path1');
+      createWorkspace('Workspace 2', '/path2');
+      
+      const workspaces = getWorkspaces();
+      
+      expect(workspaces.length).toBe(2);
+      expect(workspaces[0].name).toBe('Workspace 1');
+      expect(workspaces[1].name).toBe('Workspace 2');
+    });
+  });
+
+  describe('getWorkspaceById', () => {
+    it('should return undefined for non-existent workspace', () => {
+      const workspace = getWorkspaceById('non-existent-id');
+      expect(workspace).toBeUndefined();
+    });
+
+    it('should return the workspace with the given ID', () => {
+      const created = createWorkspace('Test Workspace', '/test/path');
+      const retrieved = getWorkspaceById(created.id);
+      
+      expect(retrieved).toBeDefined();
+      expect(retrieved?.id).toBe(created.id);
+      expect(retrieved?.name).toBe('Test Workspace');
+    });
+  });
+
+  describe('updateWorkspace', () => {
+    it('should update an existing workspace', () => {
+      const workspace = createWorkspace('Original Name', '/original/path');
+      
+      const updated = {
+        ...workspace,
+        name: 'Updated Name',
+        rootPath: '/updated/path',
+        description: 'Updated description'
+      };
+      
+      updateWorkspace(updated);
+      
+      const retrieved = getWorkspaceById(workspace.id);
+      
+      expect(retrieved?.name).toBe('Updated Name');
+      expect(retrieved?.rootPath).toBe('/updated/path');
+      expect(retrieved?.description).toBe('Updated description');
+    });
+  });
+
+  describe('deleteWorkspace', () => {
+    it('should delete an existing workspace', () => {
+      const workspace = createWorkspace('Test Workspace', '/test/path');
+      
+      deleteWorkspace(workspace.id);
+      
+      const retrieved = getWorkspaceById(workspace.id);
+      expect(retrieved).toBeUndefined();
+    });
+
+    it('should clear current workspace if deleting the current one', () => {
+      const workspace = createWorkspace('Test Workspace', '/test/path');
+      setCurrentWorkspace(workspace.id);
+      
+      deleteWorkspace(workspace.id);
+      
+      const currentId = getCurrentWorkspaceId();
+      expect(currentId).toBeNull();
+    });
+  });
+
+  describe('current workspace operations', () => {
+    it('should set and get the current workspace', () => {
+      const workspace = createWorkspace('Test Workspace', '/test/path');
+      
+      setCurrentWorkspace(workspace.id);
+      
+      const currentId = getCurrentWorkspaceId();
+      const current = getCurrentWorkspace();
+      
+      expect(currentId).toBe(workspace.id);
+      expect(current?.id).toBe(workspace.id);
+    });
+
+    it('should clear the current workspace', () => {
+      const workspace = createWorkspace('Test Workspace', '/test/path');
+      setCurrentWorkspace(workspace.id);
+      
+      clearCurrentWorkspace();
+      
+      const currentId = getCurrentWorkspaceId();
+      expect(currentId).toBeNull();
+    });
+  });
+
+  describe('ensureCurrentWorkspace', () => {
+    it('should return existing current workspace if it exists', () => {
+      const workspace1 = createWorkspace('Workspace 1', '/path1');
+      const workspace2 = createWorkspace('Workspace 2', '/path2');
+      
+      setCurrentWorkspace(workspace1.id);
+      
+      const ensured = ensureCurrentWorkspace();
+      
+      expect(ensured.id).toBe(workspace1.id);
+    });
+
+    it('should select the most recent workspace if no current workspace', () => {
+      const workspace1 = createWorkspace('Workspace 1', '/path1');
+      const workspace2 = createWorkspace('Workspace 2', '/path2');
+      
+      clearCurrentWorkspace();
+      
+      const ensured = ensureCurrentWorkspace();
+      
+      // The most recent one should be workspace2
+      expect(ensured.id).toBe(workspace2.id);
+    });
+
+    it('should create a default workspace if none exist', () => {
+      const ensured = ensureCurrentWorkspace();
+      
+      expect(ensured.name).toBe('Default Workspace');
+      expect(ensured.rootPath).toBe('/');
+      
+      const currentId = getCurrentWorkspaceId();
+      expect(currentId).toBe(ensured.id);
+    });
+  });
+});

--- a/mcp-web-client/src/services/workspaceService.ts
+++ b/mcp-web-client/src/services/workspaceService.ts
@@ -1,0 +1,171 @@
+import { Workspace } from '../types';
+
+// Local storage keys
+const WORKSPACES_KEY = 'mcp-workspaces';
+const CURRENT_WORKSPACE_KEY = 'mcp-current-workspace';
+
+// Helper function to parse dates in workspace objects
+const parseDates = (workspace: any): Workspace => {
+  return {
+    ...workspace,
+    createdAt: new Date(workspace.createdAt),
+    updatedAt: new Date(workspace.updatedAt)
+  };
+};
+
+/**
+ * Get all workspaces from local storage
+ */
+export const getWorkspaces = (): Workspace[] => {
+  const workspacesJson = localStorage.getItem(WORKSPACES_KEY);
+  
+  if (!workspacesJson) {
+    return [];
+  }
+  
+  try {
+    const parsedWorkspaces = JSON.parse(workspacesJson);
+    return parsedWorkspaces.map(parseDates);
+  } catch (error) {
+    console.error('Error parsing workspaces:', error);
+    return [];
+  }
+};
+
+/**
+ * Save all workspaces to local storage
+ */
+export const saveWorkspaces = (workspaces: Workspace[]): void => {
+  localStorage.setItem(WORKSPACES_KEY, JSON.stringify(workspaces));
+};
+
+/**
+ * Create a new workspace
+ */
+export const createWorkspace = (
+  name: string,
+  rootPath: string,
+  description: string = '',
+  icon: string = '',
+  color: string = ''
+): Workspace => {
+  const workspaces = getWorkspaces();
+  
+  const newWorkspace: Workspace = {
+    id: Date.now().toString(),
+    name,
+    rootPath,
+    description,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    icon,
+    color
+  };
+  
+  saveWorkspaces([...workspaces, newWorkspace]);
+  
+  return newWorkspace;
+};
+
+/**
+ * Get a workspace by ID
+ */
+export const getWorkspaceById = (id: string): Workspace | undefined => {
+  const workspaces = getWorkspaces();
+  return workspaces.find(workspace => workspace.id === id);
+};
+
+/**
+ * Update a workspace
+ */
+export const updateWorkspace = (updatedWorkspace: Workspace): void => {
+  const workspaces = getWorkspaces();
+  const index = workspaces.findIndex(workspace => workspace.id === updatedWorkspace.id);
+  
+  if (index !== -1) {
+    // Update the workspace with new data and update timestamp
+    workspaces[index] = {
+      ...updatedWorkspace,
+      updatedAt: new Date()
+    };
+    saveWorkspaces(workspaces);
+  }
+};
+
+/**
+ * Delete a workspace
+ */
+export const deleteWorkspace = (id: string): void => {
+  const workspaces = getWorkspaces();
+  const filteredWorkspaces = workspaces.filter(workspace => workspace.id !== id);
+  
+  // If we're deleting the current workspace, clear the current workspace
+  const currentId = getCurrentWorkspaceId();
+  if (currentId === id) {
+    clearCurrentWorkspace();
+  }
+  
+  saveWorkspaces(filteredWorkspaces);
+};
+
+/**
+ * Set the current workspace
+ */
+export const setCurrentWorkspace = (id: string): void => {
+  localStorage.setItem(CURRENT_WORKSPACE_KEY, id);
+};
+
+/**
+ * Get the current workspace ID
+ */
+export const getCurrentWorkspaceId = (): string | null => {
+  return localStorage.getItem(CURRENT_WORKSPACE_KEY);
+};
+
+/**
+ * Get the current workspace
+ */
+export const getCurrentWorkspace = (): Workspace | undefined => {
+  const currentId = getCurrentWorkspaceId();
+  
+  if (!currentId) {
+    return undefined;
+  }
+  
+  return getWorkspaceById(currentId);
+};
+
+/**
+ * Clear the current workspace
+ */
+export const clearCurrentWorkspace = (): void => {
+  localStorage.removeItem(CURRENT_WORKSPACE_KEY);
+};
+
+/**
+ * Ensure there's a current workspace selected
+ * If none is selected, select the first available workspace
+ * If no workspaces exist, create a default workspace
+ */
+export const ensureCurrentWorkspace = (): Workspace => {
+  const currentWorkspace = getCurrentWorkspace();
+  
+  if (currentWorkspace) {
+    return currentWorkspace;
+  }
+  
+  // No current workspace, check if there are any workspaces
+  const workspaces = getWorkspaces();
+  
+  if (workspaces.length > 0) {
+    // Use the most recent workspace
+    const mostRecent = workspaces.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0];
+    setCurrentWorkspace(mostRecent.id);
+    return mostRecent;
+  }
+  
+  // No workspaces at all, create a default one
+  const defaultWorkspace = createWorkspace('Default Workspace', '/', 'Default workspace created automatically');
+  setCurrentWorkspace(defaultWorkspace.id);
+  return defaultWorkspace;
+};

--- a/mcp-web-client/src/types.ts
+++ b/mcp-web-client/src/types.ts
@@ -15,6 +15,17 @@ export interface ChatSession {
   currentWorkingDirectory?: string;
 }
 
+export interface Workspace {
+  id: string;
+  name: string;
+  rootPath: string;
+  description?: string;
+  createdAt: Date;
+  updatedAt: Date;
+  icon?: string;
+  color?: string;
+}
+
 export interface McpServerConfig {
   command: string;
   args: string[];


### PR DESCRIPTION
## Description
This PR implements the Workspace Service as described in issue #4. The service provides CRUD operations for managing workspaces, with local storage persistence.

## Changes Made
- Added the `Workspace` interface to `types.ts` with fields for:
  - id
  - name
  - rootPath
  - description (optional)
  - createdAt/updatedAt timestamps
  - icon and color (optional, for UI customization)
- Created a new service file `workspaceService.ts` with the following functionality:
  - Create, read, update, and delete workspaces
  - Get all workspaces or a specific workspace by ID
  - Set, get, and clear the current workspace
  - Ensure there's always a current workspace selected
  - Local storage persistence
- Added unit tests for the workspace service to ensure it works as expected

## Implementation Details
- The workspace service follows a similar pattern to the existing chat service
- Workspace data is stored in localStorage under the 'mcp-workspaces' key
- The current workspace ID is stored in 'mcp-current-workspace'
- The service includes proper date handling when serializing/deserializing
- Error handling is implemented for missing or invalid data

## Testing
- Added comprehensive unit tests for all functions
- Tested edge cases such as:
  - Creating workspaces with required and optional fields
  - Handling non-existent workspaces
  - Deleting the current workspace
  - Creating a default workspace when none exists

## Closes
Closes #4
